### PR TITLE
Remove negative margin from sidebar

### DIFF
--- a/src/components/contribution-page.vue
+++ b/src/components/contribution-page.vue
@@ -56,7 +56,7 @@ export default {
         position: absolute;
         background: transparent;
         border: none;
-        margin-left: calc((100% - #{ $max-width }) / 2 - 5em);
+        margin-left: calc((100% - #{ $max-width }) / 2);
       }
 
       @media (max-width: $screen-md) {


### PR DESCRIPTION
As per https://github.com/adidas/adidas.github.io/issues/30
The -5em here is causing the sidebar to render outside the viewport for screen widths between 110em and 115em